### PR TITLE
PR to address second point of issue #8 (DateRangePicker too wide for screen)

### DIFF
--- a/frontend/src/components/SearchBar.js
+++ b/frontend/src/components/SearchBar.js
@@ -14,7 +14,7 @@ import { startOfMonth, endOfMonth } from 'date-fns';
 import { DateRangePicker } from 'react-date-range';
 import 'react-date-range/dist/styles.css';
 import 'react-date-range/dist/theme/default.css';
-
+import './searchBar.css'
 
 const SearchBar = ({ filterCriteria, onSearch }) => {
   const [anchorEl, setAnchorEl] = useState(null);
@@ -157,7 +157,7 @@ const SearchBar = ({ filterCriteria, onSearch }) => {
                     showSelectionPreview={true}
                     moveRangeOnFirstSelection={false}
                     months={2}
-                    direction="horizontal"
+                    direction="vertical"
                     ranges={[
                       {
                         startDate: searchQuery[key].startDate,

--- a/frontend/src/components/searchBar.css
+++ b/frontend/src/components/searchBar.css
@@ -1,0 +1,7 @@
+@media screen and (max-width: 600px) {
+    .rdrDefinedRangesWrapper {
+        display: none;
+    }
+}
+    
+


### PR DESCRIPTION
Changed to vertical DateRangePicker layout and added media rule for small screens (less than 600px) to hide the static range portion of the picker. This makes the calendar fully visible on small screens such as mobile devices. This is to address issue #8.

I did discover that the react-date-range package doesn't have support for touch/swipe, so it is not very mobile friendly. While that is an issue in the package itself and not with this project, I have forked the repo and will see if there's anything I can do to enable swipe/touch capabilities to make it easier to use on a touchscreen device.