### PR TITLE
Add admin page

### DIFF
--- a/backend/api.js
+++ b/backend/api.js
@@ -21,7 +21,7 @@ router.put('/debugLevel', secureRoute, async (req, res) => {
     logMsg("Put to /debugLevel", 4)
     const { debugLevel } = req.body;
     setDebugLevel(debugLevel);
-    logMsg(`Sending response confirming debugLevel ${debugLevel}`, 1);
+    logMsg(`Sending response confirming debugLevel ${debugLevel}`, 4);
     res.json({ debugLevel });
   } catch (error) {
     logMsg(`Sending 500 repsonse for put to /debugLevel: ${error.message}`, 1);
@@ -34,7 +34,7 @@ router.post('/workers', async (req, res) => {
     logMsg("Post to /workers",4)
     const { host, status, startTime, endTime, workerName, miningUserName } = req.body;
     const workers = await getMinerStatistics(host, workerName, status, startTime, endTime, miningUserName);
-    logMsg(`Sending response with ${workers.length} workers`, 1);
+    logMsg(`Sending response with ${workers.length} workers`, 4);
     res.json(workers);
   } catch (error) {
     logMsg(`Sending 500 repsonse for post to /workers: ${error.message}`, 1);

--- a/backend/api.js
+++ b/backend/api.js
@@ -1,10 +1,33 @@
 const express = require('express');
 const router = express.Router();
 const { getMinerStatistics, getOutages } = require('./dbFunctions');
-const { logMsg } = require('./logFunctions');
+const { logMsg, setDebugLevel } = require('./logFunctions');
 const { v4: uuidv4 } = require('uuid');
 const { fork } = require('child_process');
 const reportWorkerPath = require.resolve('./reportWorker.js');
+
+const allowedIPs = ['127.0.0.1', '::1', '::ffff:127.0.0.1', '::ffff:172.19.0.1']; // Add any other IPs you wish to allow
+const secureRoute = (req, res, next) => {
+    const clientIP = req.connection.remoteAddress;
+    if (!allowedIPs.includes(clientIP)) {
+        res.status(403).json({message: 'Access Forbidden for ' + clientIP});
+    } else {
+        next();
+    }
+};
+
+router.put('/debugLevel', secureRoute, async (req, res) => {
+  try {
+    logMsg("Put to /debugLevel", 4)
+    const { debugLevel } = req.body;
+    setDebugLevel(debugLevel);
+    logMsg(`Sending response confirming debugLevel ${debugLevel}`, 1);
+    res.json({ debugLevel });
+  } catch (error) {
+    logMsg(`Sending 500 repsonse for put to /debugLevel: ${error.message}`, 1);
+    res.status(500).json({ message: 'Error setting debugLevel', error: error.message });
+  }
+});
 
 router.post('/workers', async (req, res) => {
   try {

--- a/backend/logFunctions.js
+++ b/backend/logFunctions.js
@@ -1,4 +1,8 @@
-const debugLevel = 4;
+let debugLevel = 4;
+
+const setDebugLevel = (level) => {
+  debugLevel = level;
+}
 
 const logMsg = (msg, msgLevel=7, logLevel=debugLevel) => {
   if (msgLevel <= logLevel){
@@ -8,4 +12,5 @@ const logMsg = (msg, msgLevel=7, logLevel=debugLevel) => {
 
 module.exports = {
     logMsg,
+    setDebugLevel
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import OutageDetail from './components/OutageDetail';
 import { BrowserRouter as Router, Link, Navigate } from 'react-router-dom';
 import { Routes, Route } from 'react-router';
 import { Button } from '@mui/material';
+import AdminPage from './components/adminPage';
 
 
 const MemoizedWorkerGrid = React.memo(WorkerGrid);
@@ -18,31 +19,31 @@ function App() {
   const [searchTerm, setSearchTerm] = useState('');
   const [timeframe, setTimeframe] = useState(86400000);
   const [isLoading, setIsLoading] = useState(true);
-  
+
 
   useEffect(() => {
     // console.log("Searchterm: ",searchTerm);
     // console.log("Timeframe: ",timeframe);
-    
+
     async function fetchWorkers() {
       setIsLoading(true);
       const { host, workerName, status, miningUserName } = searchTerm;
 
       let startTime = timeframe;
       let endTime = null;
-      
-      const query = { };
+
+      const query = {};
       if (workerName) {
         query.workerName = workerName;
       }
       if (status) {
-        console.log("Status: ",status)
+        console.log("Status: ", status)
         query.status = status === 'true' ? 'up' : 'down';
       }
       if (miningUserName) {
         query.miningUserName = miningUserName;
       }
-      if(host) {
+      if (host) {
         query.host = host;
       }
       const currentTime = Date.now();
@@ -68,7 +69,7 @@ function App() {
 
     fetchWorkers();
 
-      // Refresh the data every 10 minutes
+    // Refresh the data every 10 minutes
     const refreshInterval = setInterval(() => {
       console.log('Refreshing data...' + new Date().toLocaleTimeString());
       fetchWorkers();
@@ -76,7 +77,7 @@ function App() {
 
     // Clear the interval when the component is unmounted
     return () => {
-      if(refreshInterval){
+      if (refreshInterval) {
         clearInterval(refreshInterval);
       }
     };
@@ -94,26 +95,31 @@ function App() {
       status: searchTerm.status.toString().toLowerCase(),
       host: searchTerm.host.toLowerCase(),
     };
-    setSearchTerm({...searchTerm, ...lowerCaseSearchTerm});
+    setSearchTerm({ ...searchTerm, ...lowerCaseSearchTerm });
   }
-  
+
 
   return (
     <div className="App">
       <Router>
-      <nav className="no-print" style={{display: "flex", justifyContent: "center", gridGap: "2rem", alignContent:"center", borderBottom: 'solid 5px black', padding: '5px'}}>
+        <nav className="no-print" style={{ display: "flex", justifyContent: "center", gridGap: "2rem", alignContent: "center", borderBottom: 'solid 5px black', padding: '5px' }}>
           <Link to="/workers">
-            <Button style={{margin: '5px'}} variant="contained" color="primary">
+            <Button style={{ margin: '5px' }} variant="contained" color="primary">
               Workers
             </Button>
           </Link>
           <Link to="/reports">
-              <Button style={{margin: '5px'}} variant="contained" color="primary">
-                Reports
-              </Button>
-            </Link>
+            <Button style={{ margin: '5px' }} variant="contained" color="primary">
+              Reports
+            </Button>
+          </Link>
+          <Link to="/admin">
+            <Button style={{ margin: '5px' }} variant="contained" color="primary">
+              Admin
+            </Button>
+          </Link>
         </nav>
-      
+
         <Routes>
           <Route path="/reports" element={<MemoizedReportPage />} />
           <Route
@@ -127,8 +133,9 @@ function App() {
               />
             }
           />
-          <Route path="/outageDetails/:uniqueKey" element={<MemoizedOutageDetail />}  />
+          <Route path="/outageDetails/:uniqueKey" element={<MemoizedOutageDetail />} />
           <Route path="/" element={<Navigate to="/workers" replace />} />
+          <Route path="/admin" element={<AdminPage />} />
         </Routes>
       </Router>
     </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@ import OutageDetail from './components/OutageDetail';
 import { BrowserRouter as Router, Link, Navigate } from 'react-router-dom';
 import { Routes, Route } from 'react-router';
 import { Button } from '@mui/material';
-import AdminPage from './components/adminPage';
+import AdminPage from './components/AdminPage';
 
 
 const MemoizedWorkerGrid = React.memo(WorkerGrid);

--- a/frontend/src/components/AdminPage.js
+++ b/frontend/src/components/AdminPage.js
@@ -1,0 +1,32 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+    Button,
+    CircularProgress,
+    Tooltip,
+    Slider,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+
+const updateDebugLevel = (event, value) => {
+    const requestOptions = {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ debugLevel: value })
+    };
+    fetch(process.env.REACT_APP_API_HOST + '/api/debugLevel', requestOptions)
+        .then(response => response.json())
+        .then(data => console.log(data));
+}
+
+const AdminPage = () => {
+    return (
+        <>
+            <h1>Admin Page</h1>
+            <div style={{width:'100%', position: 'fixed', margin:'auto 0'}} >
+                Debug Level:<br/> <Slider onChangeCommitted={updateDebugLevel} style={{width: '30%'}} aria-label='Debug Level' defaultValue={4} valueLabelDisplay='auto' step={1} marks min={1} max={8} />
+            </div>
+        </>
+    );
+};
+
+export default AdminPage;


### PR DESCRIPTION
I have added a very basic (work in progress) admin page. Right now, all it does is allow dynamic adjustment of the debugLevel for backend logging without needing to rebuild the backend server. More uses and controls may be added in the future. Also, with the addition of greater control over the system, the admin page may eventually need to be secured by user authentication and assigned roles.

To support the adjustment of the debugLevel, I've also updated the backend API with a route that calls a new function to set the debugLevel. The route is currently secured with a hardcoded IP whitelist that contains local IP addresses, but the IP list could eventually be moved into an environment variable or some other storage that is more easily configurable without needing to rebuild the application for changes to take effect. 