### PR TITLE
Saving startup scripts

### DIFF
--- a/backend/utils/launch_minermonitor.sh
+++ b/backend/utils/launch_minermonitor.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+# This script should be put in the /etc/profile.d/ directory to be run on startup
+cd /home/jps/programming/BTCMiningMonitor
+docker-compose up -d

--- a/backend/utils/wsl.conf
+++ b/backend/utils/wsl.conf
@@ -1,0 +1,2 @@
+[boot]
+command = service docker start


### PR DESCRIPTION
Saving these scripts which are used for automatically launching the docker containers upon starting WSL, they will need to be moved or copied to the correct directories when setting up the environment. See issue #25 for details